### PR TITLE
Add reusable pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,14 +23,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ inputs.python-version }}
-      - name: pip cache
-        id: pip_cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: pip
       - name: pre-commit cache
         id: pc_cache
         uses: actions/cache@v1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,7 @@ on:
         description: "Python version used by pre-commit."
         required: false
         type: string
-        default: 3.10
+        default: '3.10'
 
 jobs:
   lint:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,54 @@
+name: SFDO-Tooling Pre-commit Workflow
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python version used by pre-commit."
+        required: false
+        type: string
+        default: 3.10
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Set up Python ${{ inputs.python-version }}
+        id: py
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: pip cache
+        id: pip_cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: pre-commit cache
+        id: pc_cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ steps.py.outputs.python-version }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ steps.py.outputs.python-version }}-pre-commit-
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install pre-commit
+      - name: Install pre-commit
+        if: steps.pc_cache.outputs.cache-hit != 'true'
+        run: |
+          pre-commit install --install-hooks
+      - name: Run pre-commit on changed files
+        run: |
+          git fetch --depth=1 --no-tags origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
+          git fetch --depth=1 --no-tags origin $GITHUB_HEAD_REF:$GITHUB_HEAD_REF
+          pre-commit run --files $(git diff --diff-filter=d --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # .github
 Shared workflows and templates used across SFDO-Tooling repositories.
+
+## Shared Workflows
+
+The following workflows are reused across the SFDO-Tooling organization:
+
+### Docs Review
+`docs.yml`: Shared SFDO-Tooling Docs Review, which notifies documentation writers when a pull request is labeled with "doc review needed", and fails until the "docs reviewed" label is added.
+
+### Pre-Commit Linting
+`pre-commit.yml`: SFDO-Tooling Pre-commit, which provides a pre-configured workflow to run [pre-commit](https://pre-commit.com/index.html), which typically includes auto-formatters and code linting utilities.
+
+Inputs:
+  - `python-version` (default: `3.10`):specifies the python version used to run `pre-commit`.
+
+


### PR DESCRIPTION
This PR adds a workflow based on pre-commit that can be consumed across the SFDO-Tooling organization. Includes an input, `python-version`, that specifies the python version to use for pre-commit, defaults to Python 3.10.

To call from any repo, use the following syntax:

```yaml
name: Call SFDO-Tooling Pre-commit Workflow

on:
    pull_request:
        types: [opened, synchronize, reopened]

jobs:
    shared-docs:
        uses: SFDO-Tooling/.github/.github/workflows/pre-commit.yml@main
        with:
          python-version: 3.8
```
