### PR TITLE
Revise doc review workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,56 +1,61 @@
 name: Shared SFDO-Tooling Docs Review Workflow
 on:
   pull_request:
-    types:
-      - labeled
+    paths:
+      - '**.md'
+      - '**.rst'
+  pull_request_review:
+    types: [submitted]
   workflow_call:
 
 env:
-  DOCS_TEAM: 'SFDO-Tooling/doc-writers'
+  DOCS_TEAM: 'pconrad-sfdo'
+
 jobs:
   docs_review_needed:
     runs-on: ubuntu-latest
     steps:
-      - name: Labeled Doc review needed
-        id: docs-labeled-review-needed
-        if: github.event.action == 'labeled' && !github.event.pull_request.draft &&
-            contains(github.event.label.name, 'doc review needed')
+      - name: Document review needed (RST/MD)
+        id: docs-filetypes-review-needed
+        if: !github.event.pull_request.draft &&
+            !contains(github.event.issue.labels.*.name, 'doc review needed') &&
+            !contains(github.event.pull_request.requested_reviewers.*.login, env.DOCS_TEAM) &&
         uses: SFDO-Tooling/github-script@v4
         with:
           script: |
-            const comment_body = `This pull request has been labeled as ready for docs review and requires review from @${process.env.DOCS_TEAM}. This workflow will fail until this pull request is labeled as 'docs reviewed'.`
-
-            github.issues.createComment({
+            github.pulls.requestReviewers({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: comment_body,
+              reviewers: ["${process.env.DOCS_TEAM}"],
+            });
+
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['doc review needed'],
             });
 
             core.setFailed('PR requires doc review.');
-      - name: Labeled Doc review complete
-        id: docs-labeled-reviewed
-        if: github.event.action == 'labeled' && !github.event.pull_request.draft &&
-            contains(github.event.label.name, 'docs reviewed')
+  docs_reviewed:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_review' &&
+        github.event.review.state == 'approved' &&
+        github.event.review.user.login == env.DOCS_TEAM &&
+    steps:
+      - name: Remove review needed label
+        id: rm-docs-review-label
+        if: contains(github.event.issue.labels.*.name, 'doc review needed')
         uses: SFDO-Tooling/github-script@v4
         with:
           script: |
-            const comment_body = `This pull request has been labeled as reviewed by @${context.payload.sender.login}.`
-
-            github.issues.createComment({
+            github.issues.removeLabel({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: comment_body,
+              name: 'doc review needed',
             });
-
-            try {
-              github.issues.removeLabel({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: 'doc review needed',
-              });
-            } catch (err) {
-              console.error(err);
-            }
+      - name: Doc review complete
+        id: docs-reviewed
+        run: exit 0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Shared workflows and templates used across SFDO-Tooling repositories.
 The following workflows are reused across the SFDO-Tooling organization:
 
 ### Docs Review
-`docs.yml`: Shared SFDO-Tooling Docs Review, which notifies documentation writers when a pull request is labeled with "doc review needed", and fails until the "docs reviewed" label is added.
+`docs.yml`: Shared SFDO-Tooling Docs Review, which requests review from a technical writer when a pull request modifies markdown or RestructuredText files, and fails until the writer approves the PR.
 
 ### Pre-Commit Linting
 `pre-commit.yml`: SFDO-Tooling Pre-commit, which provides a pre-configured workflow to run [pre-commit](https://pre-commit.com/index.html), which typically includes auto-formatters and code linting utilities.


### PR DESCRIPTION
Updated to allow a more traditional PR review process for docs. Now the workflow is triggered:
- on PR creation iff:
  - docs reviewer has not been requested, and
  - PR is unlabeled
- on review submission if:
  - docs reviewer approves
  - removes label if present