### PR TITLE
Use email for Github Actions bot

### DIFF
--- a/.github/workflows/update_python_dependencies.yml
+++ b/.github/workflows/update_python_dependencies.yml
@@ -32,8 +32,8 @@ jobs:
             - name: Commit changes and open PR
               run: |
                   export WEEK="w$(date +%V)"
-                  git config user.name github-actions
-                  git config user.email github-actions@github.com
+                  git config user.name github-actions[bot]
+                  git config user.email 41898282+github-actions[bot]@users.noreply.github.com
                   git switch -c "dependency-updates-$WEEK"
                   git add requirements/*.txt 
                   git commit -m "$WEEK dependency updates (automated)"


### PR DESCRIPTION
Our company's tooling retrieves a list of commits for each pull request
and checks whether the commit's author has signed a Contributor License
Agreement. It filters bot accounts by checking the `type` property for
the string ["Bot"]. However, commits made using the GITHUB_ACTIONS token
are showing up as `type` "User". This is [WAD], however. The workaround
is to use the bot's ID to prefix the email address.

See: actions/checkout#1184

["Bot"]: https://github.com/salesforce/dr-cla/blob/290a3a1d/app/utils/GitHub.scala#L515-L519
[WAD]: https://github.com/orgs/community/discussions/26560#discussioncomment-3252337
